### PR TITLE
enable m68k-linux-mlibc target

### DIFF
--- a/build-many-tools.bash
+++ b/build-many-tools.bash
@@ -4,6 +4,7 @@ targets=(
     x86_64-linux-mlibc
     aarch64-linux-mlibc
     i686-linux-mlibc
+    m68k-linux-mlibc
 )
 
 set -xe


### PR DESCRIPTION
I tested this locally and it seemed to "just work".
Blocked on https://github.com/managarm/mlibc/pull/1149